### PR TITLE
fix(ci): install protoc on Windows for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,12 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --system core.longpaths true
       - uses: actions/checkout@v6
-      - run: bash .github/setup-ci.sh
+      - name: Install dependencies (Unix)
         if: runner.os != 'Windows'
+        run: bash .github/setup-ci.sh
+      - name: Install protoc (Windows)
+        if: runner.os == 'Windows'
+        run: choco install protoc -y
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}


### PR DESCRIPTION
## Summary

- Adds protoc installation step for Windows in the release workflow
- The milvus-sdk-rust build script requires protoc, which was only installed on Unix via setup-ci.sh

## Context

Release v0.1.4 workflow failed on Windows with:
```
Could not find `protoc`. If `protoc` is installed, try setting the `PROTOC` environment variable...
```

## Test plan

- [ ] Release workflow Windows build passes with protoc available