### PR TITLE
chore: bump version to 0.3.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3247,8 +3247,8 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2",
- "strum 0.27.2",
- "strum_macros 0.27.2",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -6166,9 +6166,9 @@ checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "strum_macros"
@@ -6185,9 +6185,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "mcb"
-version = "0.2.1"
+version = "0.3.0-dev"
 dependencies = [
  "clap",
  "insta",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "mcb-application"
-version = "0.2.1"
+version = "0.3.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3228,7 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "mcb-domain"
-version = "0.2.1"
+version = "0.3.0-dev"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "mcb-infrastructure"
-version = "0.2.1"
+version = "0.3.0-dev"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3337,7 +3337,7 @@ dependencies = [
 
 [[package]]
 name = "mcb-providers"
-version = "0.2.1"
+version = "0.3.0-dev"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3393,7 +3393,7 @@ dependencies = [
 
 [[package]]
 name = "mcb-server"
-version = "0.2.1"
+version = "0.3.0-dev"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3446,7 +3446,7 @@ dependencies = [
 
 [[package]]
 name = "mcb-validate"
-version = "0.2.1"
+version = "0.3.0-dev"
 dependencies = [
  "async-trait",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/marlonsc/mcb"
 authors = ["Marlon Costa <marlonsc@gmail.com>"]
 homepage = "https://github.com/marlonsc/mcb"
 license = "MIT"
-version = "0.2.1"
+version = "0.3.0-dev"
 rust-version = "1.92"
 edition = "2024"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,8 +233,8 @@ async-trait = "0.1"
 downcast-rs = "2.0"
 futures-util = "0.3"
 derive_more = { version = "2.0", features = ["full"] }
-strum = "0.27"
-strum_macros = "0.27"
+strum = "0.28"
+strum_macros = "0.28"
 delegate = "0.13"
 typed-builder = "0.23"
 


### PR DESCRIPTION
### **User description**
## Summary

Post-release version bump after tagging v0.2.1.

- Bumps workspace version from `0.2.1` to `0.3.0-dev` in `Cargo.toml`
- Updates `Cargo.lock` accordingly

This is a routine post-release housekeeping commit. No code changes.


___

### **PR Type**
Enhancement


___

### **Description**
- Bump workspace version to 0.3.0-dev post-release

- Upgrade strum and strum_macros from 0.27 to 0.28

- Verified with cargo check and clippy


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cargo.toml"] -->|"version bump"| B["0.3.0-dev"]
  A -->|"strum upgrade"| C["0.28"]
  A -->|"strum_macros upgrade"| D["0.28"]
  C -->|"verified"| E["cargo check & clippy"]
```


<hr>
<details> <summary><strong>🛠️ Relevant configurations:</strong></summary> 

<br>These are the relevant [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml) for this tool:

**[config**]
```yaml

is_auto_command: True
PR_COMPLIANCE: {'ENABLE_RULES_PLATFORM': True}
model_reasoning: vertex_ai/gemini-2.5-pro
model: openai/gpt-5.2
model_turbo: anthropic/claude-haiku-4-5-20251001
fallback_models: ['anthropic/claude-sonnet-4-6', 'openai/gpt-5.2', 'bedrock/us.anthropic.claude-sonnet-4-6']
second_model_for_exhaustive_mode: o4-mini
git_provider: github
publish_output: True
publish_output_no_suggestions: True
publish_output_progress: True
verbosity_level: 0
publish_logs: False
debug_mode: False
use_wiki_settings_file: True
use_repo_settings_file: True
use_global_settings_file: True
use_global_wiki_settings_file: False
disable_auto_feedback: False
ai_timeout: 150
response_language: en-US
clone_repo_instead_of_fetch: True
always_clone: False
add_repo_metadata: True
clone_repo_time_limit: 300
publish_inline_comments_fallback_batch_size: 5
publish_inline_comments_fallback_sleep_time: 2
max_model_tokens: 32000
custom_model_max_tokens: -1
patch_extension_skip_types: ['.md', '.txt']
extra_allowed_extensions: []
allow_dynamic_context: True
allow_forward_dynamic_context: True
max_extra_lines_before_dynamic_context: 12
patch_extra_lines_before: 5
patch_extra_lines_after: 1
ai_handler: litellm
cli_mode: False
TRIAL_GIT_ORG_MAX_INVOKES_PER_MONTH: 30
TRIAL_RATIO_CLOSE_TO_LIMIT: 0.8
invite_only_mode: False
enable_request_access_msg_on_new_pr: False
check_also_invites_field: False
allowed_users: []
calculate_context: True
disable_checkboxes: False
output_relevant_configurations: True
large_patch_policy: clip
seed: -1
temperature: 0.2
allow_dynamic_context_ab_testing: False
choose_dynamic_context_ab_testing_ratio: 0.5
ignore_pr_title: ['^\\[Auto\\]', '^Auto']
ignore_pr_target_branches: []
ignore_pr_source_branches: []
ignore_pr_labels: []
ignore_ticket_labels: []
allow_only_specific_folders: []
ignore_pr_authors: []
ignore_repositories: []
ignore_language_framework: []
is_new_pr: False
enable_ai_metadata: True
present_reasoning: True
max_tickets: 10
max_tickets_chars: 8000
prevent_any_approval: False
enable_comment_approval: False
enable_auto_approval: False
auto_approve_for_low_review_effort: -1
auto_approve_for_no_suggestions: False
ensure_ticket_compliance: False
new_diff_format: True
new_diff_format_add_external_references: True
tasks_queue_ttl_from_dequeue_in_seconds: 900
enable_custom_labels: False
reasoning_effort: high

```

**[pr_description]**
```yaml

final_update_message: False
publish_labels: True
add_original_user_description: True
generate_ai_title: False
extra_instructions: 
enable_pr_type: True
enable_help_text: False
enable_help_comment: False
bring_latest_tag: False
enable_pr_diagram: True
publish_description_as_comment: False
publish_description_as_comment_persistent: True
enable_semantic_files_types: True
collapsible_file_list: adaptive
collapsible_file_list_threshold: 8
inline_file_summary: table
use_description_markers: False
include_generated_by_header: True
enable_large_pr_handling: True
max_ai_calls: 4
auto_create_ticket: False
use_bullet_points: True
async_ai_calls: True

```
</details>
