### PR TITLE
merge: sync develop with sccache CI fix

### DIFF
--- a/custom.mk
+++ b/custom.mk
@@ -5,6 +5,13 @@ post-setup:
 	@hooks_dir=$$(git rev-parse --git-path hooks); \
 		cp scripts/hooks/pre-commit scripts/hooks/pre-push "$$hooks_dir/"; \
 		chmod +x "$$hooks_dir/pre-commit" "$$hooks_dir/pre-push"
+	@# Why (mcb-o96i.19): CI runners need sccache installed before any cargo
+	@# invocation because .cargo/config.toml sets rustc-wrapper = "sccache".
+	@# The setup-ci.sh script installs sccache when not present. On local
+	@# machines where sccache is already installed this is a no-op.
+	@if [ "$$CI" = "Y" ] && [ -f .github/setup-ci.sh ]; then \
+		bash .github/setup-ci.sh; \
+	fi
 	@printf '%s\n' 'MCB hooks installed'
 
 _custom_build_artifacts:


### PR DESCRIPTION
Adds sccache provisioning in post-setup for CI runners. Closes mcb-o96i.19.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install `sccache` during `post-setup` on CI runners to prevent `cargo` failures when `.cargo/config.toml` sets `rustc-wrapper = sccache`. Closes Linear issue mcb-o96i.19.

- **Bug Fixes**
  - When `CI=Y`, run `.github/setup-ci.sh` to install `sccache`; local machines with `sccache` already installed are unaffected.

<sup>Written for commit b6562220124a25527880b3e13f416ed01f4d2bce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marlonsc/mcb/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

