### PR TITLE
merge: sync develop with FileHashService dyn-compat fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/mcb-domain/src/ports/services/hash_service.rs
+++ b/crates/mcb-domain/src/ports/services/hash_service.rs
@@ -31,5 +31,5 @@ pub trait FileHashService: Send + Sync {
     /// # Errors
     ///
     /// Returns an error if the file cannot be opened or read.
-    fn compute_hash(path: &Path) -> Result<String>;
+    fn compute_hash(&self, path: &Path) -> Result<String>;
 }

--- a/crates/mcb-server/src/controllers/health_api.rs
+++ b/crates/mcb-server/src/controllers/health_api.rs
@@ -2,6 +2,7 @@
 
 use crate::state::McbState;
 use axum::extract::Extension;
+use axum::http::StatusCode;
 use loco_rs::prelude::*;
 
 /// Returns health status of embedding and vector store providers.
@@ -44,6 +45,37 @@ pub async fn alive() -> Result<Response> {
     format::json(serde_json::json!({
         "status": "alive",
     }))
+}
+
+/// Returns dependency readiness for infrastructure probes.
+///
+/// # Errors
+///
+/// Returns an error if JSON response serialization fails.
+pub async fn ready(Extension(state): Extension<McbState>) -> Result<Response> {
+    let ready = state.embedding_provider.health_check().await.is_ok()
+        && state.vector_store.health_check().await.is_ok();
+    let status = if ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+
+    let mut response = format::json(serde_json::json!({
+        "status": if ready { "ready" } else { "unready" },
+    }))?;
+    *response.status_mut() = status;
+    Ok(response)
+}
+
+/// Returns the currently empty metrics payload.
+///
+/// # Errors
+///
+/// Returns an error if JSON response serialization fails.
+pub async fn metrics() -> Result<Response> {
+    // Prometheus exposition is a future enhancement; the stub returns an empty JSON object.
+    format::json(serde_json::json!({}))
 }
 
 /// Registers health API routes.

--- a/crates/mcb-server/src/controllers/routes.rs
+++ b/crates/mcb-server/src/controllers/routes.rs
@@ -18,9 +18,11 @@ use tokio_util::sync::CancellationToken;
 use crate::McpServer;
 use crate::state::McbState;
 
-/// Public routes — no auth required (static assets + redirect).
-pub fn build_public_routes() -> AxumRouter {
-    axum::Router::new()
+/// Public routes — no auth required (health endpoints, static assets, and redirect).
+pub fn build_public_routes(metrics_enabled: bool) -> AxumRouter {
+    let router = axum::Router::new()
+        .route("/alive", axum::routing::get(super::health_api::alive))
+        .route("/ready", axum::routing::get(super::health_api::ready))
         .route(
             "/",
             axum::routing::get(|| async { axum::response::Redirect::temporary("/ui/") }),
@@ -51,7 +53,13 @@ pub fn build_public_routes() -> AxumRouter {
                     include_str!("../../../../assets/admin/ui/shared.js"),
                 )
             }),
-        )
+        );
+
+    if metrics_enabled {
+        router.route("/metrics", axum::routing::get(super::health_api::metrics))
+    } else {
+        router
+    }
 }
 
 /// Admin web UI page routes.
@@ -151,10 +159,18 @@ pub fn build_router_without_fallback(
     mcp_server: Arc<McpServer>,
     settings: Option<serde_json::Value>,
 ) -> AxumRouter {
+    let metrics_enabled = settings
+        .as_ref()
+        .and_then(|settings| settings.get("system"))
+        .and_then(|system| system.get("infrastructure"))
+        .and_then(|infrastructure| infrastructure.get("metrics"))
+        .and_then(|metrics| metrics.get("endpoint_enabled"))
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
     let protected_routes = build_protected_routes(state.clone(), settings);
 
     AxumRouter::new()
-        .merge(build_public_routes())
+        .merge(build_public_routes(metrics_enabled))
         .merge(protected_routes)
         .layer(axum::Extension(state))
         .merge(build_mcp_router(mcp_server))


### PR DESCRIPTION
Adds 145b2b537 fix(domain): make FileHashService dyn-compatible with &self on compute_hash. Fast-forward sync.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `FileHashService` trait-object compatible by changing `compute_hash` to take `&self`; update implementations and call sites. Add public `/alive` and dependency-aware `/ready` endpoints, an optional `/metrics` endpoint (enabled via settings), and bump `crossbeam-epoch` to `0.9.20`.

<sup>Written for commit b1b40f05f2750732feb8ce1d65bd715fa8bf999d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marlonsc/mcb/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

